### PR TITLE
COASTAL-625: Relax requirement that HUDProvider needs to provide LevelHUDView

### DIFF
--- a/MinimedKitUI/MinimedHUDProvider.swift
+++ b/MinimedKitUI/MinimedHUDProvider.swift
@@ -67,7 +67,7 @@ class MinimedHUDProvider: HUDProvider {
         }
     }
 
-    public func createHUDView() -> LevelHUDView? {
+    public func createHUDView() -> BaseHUDView? {
 
         reservoirView = ReservoirHUDView.instantiate()
 
@@ -95,7 +95,7 @@ class MinimedHUDProvider: HUDProvider {
         return rawValue
     }
 
-    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> LevelHUDView? {
+    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> BaseHUDView? {
         guard let pumpReservoirCapacity = rawValue["pumpReservoirCapacity"] as? Double else {
             return nil
         }

--- a/MinimedKitUI/MinimedPumpManager+UI.swift
+++ b/MinimedKitUI/MinimedPumpManager+UI.swift
@@ -59,7 +59,7 @@ extension MinimedPumpManager: PumpManagerUI {
         return MinimedHUDProvider(pumpManager: self, bluetoothProvider: bluetoothProvider, colorPalette: colorPalette, allowedInsulinTypes: allowedInsulinTypes)
     }
     
-    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> LevelHUDView? {
+    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> BaseHUDView? {
         return MinimedHUDProvider.createHUDView(rawValue: rawValue)
     }
 }

--- a/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
+++ b/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
@@ -62,7 +62,7 @@ extension OmnipodPumpManager: PumpManagerUI {
         return OmnipodHUDProvider(pumpManager: self, bluetoothProvider: bluetoothProvider, colorPalette: colorPalette, allowedInsulinTypes: allowedInsulinTypes)
     }
     
-    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> LevelHUDView? {
+    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> BaseHUDView? {
         return OmnipodHUDProvider.createHUDView(rawValue: rawValue)
     }
 

--- a/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
+++ b/OmniKitUI/PumpManager/OmnipodHUDProvider.swift
@@ -86,7 +86,7 @@ internal class OmnipodHUDProvider: NSObject, HUDProvider, PodStateObserver {
         }
     }
         
-    public func createHUDView() -> LevelHUDView? {
+    public func createHUDView() -> BaseHUDView? {
         self.reservoirView = OmnipodReservoirView.instantiate()
         self.updateReservoirView()
 


### PR DESCRIPTION
LevelHUDView is for providing a view that displays a thermometer level, which not all Pumps may provide.  This relaxes the requirement and just requires returning a BaseHUDView.

https://tidepool.atlassian.net/browse/COASTAL-625